### PR TITLE
feat(selector): draggable bottomsheet country selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.0.1] - 
+- added DraggableModalBottomSheet
+
 ## [3.0.0] - 27 / 08 / 2021
 - removed deprecated selector config
 - added controllers to control the value

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:example/widgets/switch_el.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-
 import 'package:phone_form_field/phone_form_field.dart';
 
 void main() {
@@ -129,39 +128,36 @@ class _PhoneFormFieldScreenState extends State<PhoneFormFieldScreen> {
                       onChanged: (v) => setState(() => mobileOnly = v),
                       title: 'Mobile phone number only',
                     ),
-                    Text('country selector: '),
-                    SingleChildScrollView(
-                      child: Row(
-                        children: [
-                          Radio(
-                            value: const BottomSheetNavigator(),
-                            groupValue: selectorNavigator,
-                            onChanged: (CountrySelectorNavigator? value) {
-                              setState(() => selectorNavigator =
-                                  value ?? BottomSheetNavigator());
-                            },
-                          ),
-                          Text('bottom sheet'),
-                          Radio(
-                            value: const ModalBottomSheetNavigator(),
-                            groupValue: selectorNavigator,
-                            onChanged: (CountrySelectorNavigator? value) {
-                              setState(() => selectorNavigator =
-                                  value ?? const ModalBottomSheetNavigator());
-                            },
-                          ),
-                          Text('modal sheet'),
-                          Radio(
-                            value: const DialogNavigator(),
-                            groupValue: selectorNavigator,
-                            onChanged: (CountrySelectorNavigator? value) {
-                              setState(() => selectorNavigator =
-                                  value ?? const DialogNavigator());
-                            },
-                          ),
-                          Text('dialog'),
-                        ],
-                      ),
+                    Row(
+                      children: [
+                        Text('Country selector: '),
+                        DropdownButton<CountrySelectorNavigator>(
+                          value: selectorNavigator,
+                          onChanged: (CountrySelectorNavigator? value) {
+                            if (value != null) {
+                              setState(() => selectorNavigator = value);
+                            }
+                          },
+                          items: [
+                            DropdownMenuItem(
+                              child: Text('Bottom sheet'),
+                              value: const BottomSheetNavigator(),
+                            ),
+                            DropdownMenuItem(
+                              child: Text('Modal sheet'),
+                              value: const ModalBottomSheetNavigator(),
+                            ),
+                            DropdownMenuItem(
+                              child: Text('Dialog'),
+                              value: const DialogNavigator(),
+                            ),
+                            DropdownMenuItem(
+                              child: Text('Draggable modal sheet'),
+                              value: const DraggableModalBottomSheetNavigator(),
+                            ),
+                          ],
+                        ),
+                      ],
                     ),
                     SizedBox(
                       height: 40,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,8 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
   phone_form_field:
-    git:
-      url: https://github.com/cedvdb/phone_form_field
+    path: ../
 
   flutter_localizations: # Add this line
     sdk: flutter  

--- a/lib/src/widgets/country_picker/country_list.dart
+++ b/lib/src/widgets/country_picker/country_list.dart
@@ -2,23 +2,25 @@ import 'package:circle_flags/circle_flags.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import '../../models/country.dart';
 import '../../localization/phone_field_localization.dart';
+import '../../models/country.dart';
 
 class CountryList extends StatelessWidget {
   final Function(Country) onTap;
   final List<Country> countries;
+  final ScrollController? scrollController;
 
   const CountryList({
     Key? key,
     required this.countries,
     required this.onTap,
+    this.scrollController,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
-      // controller: widget.scrollController,
+      controller: scrollController,
       shrinkWrap: true,
       itemCount: countries.length,
       itemBuilder: (BuildContext context, int index) {

--- a/lib/src/widgets/country_picker/country_selector.dart
+++ b/lib/src/widgets/country_picker/country_selector.dart
@@ -9,10 +9,12 @@ import 'country_list.dart';
 class CountrySelector extends StatefulWidget {
   final List<Country> countries;
   final Function(Country) onCountrySelected;
+  final ScrollController? scrollController;
 
   CountrySelector({
     Key? key,
     required this.onCountrySelected,
+    this.scrollController,
     List<Country>? countries,
   })  : countries = countries ?? allCountries,
         super(key: key);
@@ -47,13 +49,13 @@ class _CountrySelectorState extends State<CountrySelector> {
             onChanged: _onSearch,
           ),
         ),
-        Expanded(
-          flex: 9,
+        Flexible(
           child: CountryList(
             countries: _filteredCountries,
             onTap: (country) {
               widget.onCountrySelected(country);
             },
+            scrollController: widget.scrollController,
           ),
         ),
       ],

--- a/lib/src/widgets/country_picker/country_selector_navigator.dart
+++ b/lib/src/widgets/country_picker/country_selector_navigator.dart
@@ -6,9 +6,6 @@ import 'package:phone_form_field/src/models/country.dart';
 import 'country_selector.dart';
 
 abstract class CountrySelectorNavigator {
-  final List<Country>? countries;
-
-  const CountrySelectorNavigator({this.countries});
   Future<Country?> navigate(BuildContext context);
 }
 
@@ -35,6 +32,7 @@ class BottomSheetNavigator implements CountrySelectorNavigator {
   final List<Country>? countries;
 
   const BottomSheetNavigator({this.countries});
+
   @override
   Future<Country?> navigate(BuildContext context) {
     late Country selected;
@@ -68,6 +66,59 @@ class ModalBottomSheetNavigator implements CountrySelectorNavigator {
           countries: countries ?? allCountries,
           onCountrySelected: (country) => Navigator.pop(context, country),
         ),
+      ),
+      isScrollControlled: true,
+    );
+  }
+}
+
+class DraggableModalBottomSheetNavigator implements CountrySelectorNavigator {
+  final List<Country>? countries;
+  final double initialChildSize;
+  final double minChildSize;
+  final double maxChildSize;
+  final BorderRadiusGeometry? borderRadius;
+
+  const DraggableModalBottomSheetNavigator({
+    this.countries,
+    this.initialChildSize = 0.5,
+    this.minChildSize = 0.25,
+    this.maxChildSize = 0.85,
+    this.borderRadius,
+  });
+
+  @override
+  Future<Country?> navigate(BuildContext context) {
+    final effectiveBorderRadius = borderRadius ??
+        BorderRadius.only(
+          topLeft: Radius.circular(16),
+          topRight: Radius.circular(16),
+        );
+    return showModalBottomSheet<Country>(
+      context: context,
+      shape: RoundedRectangleBorder(
+        borderRadius: effectiveBorderRadius,
+      ),
+      builder: (_) => DraggableScrollableSheet(
+        initialChildSize: initialChildSize,
+        minChildSize: minChildSize,
+        maxChildSize: maxChildSize,
+        expand: false,
+        builder: (context, scrollController) {
+          return Container(
+            decoration: ShapeDecoration(
+              color: Theme.of(context).canvasColor,
+              shape: RoundedRectangleBorder(
+                borderRadius: effectiveBorderRadius,
+              ),
+            ),
+            child: CountrySelector(
+              countries: countries ?? allCountries,
+              onCountrySelected: (country) => Navigator.pop(context, country),
+              scrollController: scrollController,
+            ),
+          );
+        },
       ),
       isScrollControlled: true,
     );

--- a/lib/src/widgets/phone_form_field.dart
+++ b/lib/src/widgets/phone_form_field.dart
@@ -158,6 +158,7 @@ class _PhoneFormFieldState extends State<PhoneFormField> {
       decoration: widget.decoration,
       autofocus: widget.autofocus,
       defaultCountry: widget.defaultCountry,
+      selectorNavigator: widget.selectorNavigator,
     );
   }
 }


### PR DESCRIPTION
**PR Type**
New Feature

**Breaking changes**
None

**Description:**
Add a new CountrySelectorNavigator : `DraggableModalBottomSheetNavigator`

_Available parameters:_
- countries (optional, default: all countries)
- initialChildSize (optional, default: .5)
- minChildSize (optional, default: .25)
- maxChildSize (optional, default: .85)
- borderRadius (optional, default: topLeft/topRight with circular border of 16)


_Side Note changes_

- remove the constructor and `countries` property in abstract `CountrySelectorNavigator` as it's confusing to have the same property in extended and abstract class (abstract one is useless when implementation don't call super) and it breaks interface/implementation separation concerns, so I just keep the mandatory method `navigate`.
- update the example `pubspec.yaml` to use current local dev version using relative path.
- update the example layout to use dropdown instead of radio as previous layout was failing to fit in mobile screens


_Example screen record:_

https://user-images.githubusercontent.com/6652177/131473911-b74b2068-325b-4ee7-bbda-2043f218352c.mp4

