### PR TITLE
fix(controller): dispose only controller created locally

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:example/widgets/switch_el.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-
 import 'package:phone_form_field/phone_form_field.dart';
 
 void main() {
@@ -74,7 +73,7 @@ class PhoneFormFieldScreen extends StatefulWidget {
 }
 
 class _PhoneFormFieldScreenState extends State<PhoneFormFieldScreen> {
-  final PhoneController controller = PhoneController(null);
+  late PhoneController controller;
   bool outlineBorder = true;
   bool withLabel = true;
   bool autovalidate = true;
@@ -84,7 +83,14 @@ class _PhoneFormFieldScreenState extends State<PhoneFormFieldScreen> {
   @override
   initState() {
     super.initState();
+    controller = PhoneController(null);
     controller.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    controller.dispose();
   }
 
   // _getSubmitState() {

--- a/lib/src/widgets/base_phone_form_field.dart
+++ b/lib/src/widgets/base_phone_form_field.dart
@@ -74,8 +74,10 @@ class _BasePhoneFormFieldState extends FormFieldState<PhoneNumberInput> {
   late final TextEditingController _nationalController;
   late final ValueNotifier<String> _isoCodeController;
   late final ValueNotifier<PhoneNumberInput?> _phoneController;
+
   @override
   BasePhoneFormField get widget => super.widget as BasePhoneFormField;
+
   bool get isOutlineBorder => widget.decoration.border is OutlineInputBorder;
 
   _BasePhoneFormFieldState();
@@ -102,7 +104,11 @@ class _BasePhoneFormFieldState extends FormFieldState<PhoneNumberInput> {
     _focusNode.dispose();
     _nationalController.dispose();
     _isoCodeController.dispose();
-    _phoneController.dispose();
+    // dispose the phoneController only when it's initialised in this
+    // instance otherwise this should be done where instance is created
+    if (widget.controller == null) {
+      _phoneController.dispose();
+    }
     super.dispose();
   }
 

--- a/lib/src/widgets/phone_form_field.dart
+++ b/lib/src/widgets/phone_form_field.dart
@@ -81,7 +81,11 @@ class _PhoneFormFieldState extends State<PhoneFormField> {
   void dispose() {
     super.dispose();
     baseController.dispose();
-    controller.dispose();
+    // dispose the controller only when it's initialised in this instance
+    // otherwise this should be done where instance is created
+    if (widget.controller == null) {
+      controller.dispose();
+    }
   }
 
   void _onControllerChange() {


### PR DESCRIPTION
Dispose controllers in `dispose` method only when controller is instantiated in initState method of the same class otherwise this should be done in the parent widget where the controller is instantiated.

Fix issue #11