### PR TITLE
chore(i18n): Update "Portugal" country translation

### DIFF
--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -179,7 +179,7 @@
   "PN": "Pitcairn",
   "PR": "Porto Rico",
   "PS": "Territoire palestinien, occupé",
-  "PT": "le Portugal",
+  "PT": "Portugal",
   "PW": "Palau",
   "PY": "Paraguay",
   "QA": "Qatar",


### PR DESCRIPTION
Remove prefix `le `

I think it's a mistake:

Previous translation : `le Portugal`
Updated to : `Portugal`