### PR TITLE
Forward hintStyle to the inner InputDecoration

### DIFF
--- a/lib/src/widgets/phone_field_state.dart
+++ b/lib/src/widgets/phone_field_state.dart
@@ -180,6 +180,7 @@ class _PhoneFieldState extends State<PhoneField> {
   InputDecoration _getInnerInputDecoration() {
     return InputDecoration.collapsed(
       hintText: widget.decoration.hintText,
+      hintStyle: widget.decoration.hintStyle,
     ).copyWith(
       focusedBorder: InputBorder.none,
       errorBorder: InputBorder.none,


### PR DESCRIPTION
I was surprised that `hintStyle` had no impact. I had to use the Theme to apply my colour. 
WDYT?