### PR TITLE
feat: migrate to use the svg version of circle_flags which is flutter_circle_flags_svg

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -22,13 +22,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
-  circle_flags:
-    dependency: transitive
-    description:
-      name: circle_flags
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.3"
   clock:
     dependency: transitive
     description:
@@ -69,6 +62,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_circle_flags_svg:
+    dependency: transitive
+    description:
+      name: flutter_circle_flags_svg
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -81,11 +81,39 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_svg:
+    dependency: transitive
+    description:
+      name: flutter_svg
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.6"
+  flutter_svg_provider:
+    dependency: transitive
+    description:
+      name: flutter_svg_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.5"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.2"
   intl:
     dependency: transitive
     description:
@@ -128,13 +156,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.0"
   phone_form_field:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "7.0.1"
+    version: "7.0.2"
   phone_number_metadata:
     dependency: transitive
     description:
@@ -196,6 +245,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.12"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
@@ -203,6 +259,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.0"
 sdks:
-  dart: ">=2.17.0-206.0.dev <3.0.0"
+  dart: ">=2.18.2 <3.0.0"
   flutter: ">=3.0.0"

--- a/lib/src/widgets/country_code_chip.dart
+++ b/lib/src/widgets/country_code_chip.dart
@@ -1,4 +1,4 @@
-import 'package:circle_flags/circle_flags.dart';
+import 'package:flutter_circle_flags_svg/flutter_circle_flags_svg.dart';
 import 'package:flutter/material.dart';
 import 'package:phone_form_field/src/models/iso_code.dart';
 

--- a/lib/src/widgets/country_selector/country_list.dart
+++ b/lib/src/widgets/country_selector/country_list.dart
@@ -1,4 +1,4 @@
-import 'package:circle_flags/circle_flags.dart';
+import 'package:flutter_circle_flags_svg/flutter_circle_flags_svg.dart';
 import 'package:flutter/material.dart';
 import 'package:phone_form_field/l10n/generated/phone_field_localization.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_localizations: # Add this line
     sdk: flutter
 
-  circle_flags: ^0.0.3
+  flutter_circle_flags_svg: ^1.0.4
   phone_numbers_parser: ^7.0.0
   dart_countries: ^3.0.2
   intl: ^0.17.0

--- a/test/phone_form_field_test.dart
+++ b/test/phone_form_field_test.dart
@@ -1,4 +1,4 @@
-import 'package:circle_flags/circle_flags.dart';
+import 'package:flutter_circle_flags_svg/flutter_circle_flags_svg.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Previously we were using the circle_flags package, which uses png version of flags, and which causes large bundle because of PNG's compression nature. Now we are using flutter_circle_flags_svg which only costs about 130KB to bundle size.