### PR TITLE
feature: allow searching by ISO code

### DIFF
--- a/lib/src/helpers/country_finder.dart
+++ b/lib/src/helpers/country_finder.dart
@@ -74,7 +74,8 @@ class CountryFinder {
 
     _filteredCountries = _allCountries.where((country) {
       final countryName = removeDiacritics(country.name.toLowerCase());
-      return countryName.contains(searchTxt);
+      return countryName.contains(searchTxt) ||
+          country.isoCode.name.toLowerCase().contains(searchTxt);
     }).toList()
       // puts the ones that begin by txt first
       ..sort(compareCountries);


### PR DESCRIPTION
I was missing a way to quickly search a country by ISO code, e.g. "US" for United States, or "DK" for "Denmark".

This PR enables that functionality.

And oh, thanks for a super sweet library. Well done! I've been wasting too much time today trying 3-4 different libraries and trying to customize them to my needs, only to find this is by far the best library for Flutter out there.