### PR TITLE
Widen package:intl version constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   circle_flags: ^1.0.4
   phone_numbers_parser: ^7.0.2
   dart_countries: ^3.0.3
-  intl: ^0.17.0
+  intl: '>=0.17.0 <=0.19.0'
   diacritic: ^0.1.3
 
 dev_dependencies:


### PR DESCRIPTION
Latest version of Flutter requires `v0.18.0`.