### PR TITLE
change Turkey to Türkiye

### DIFF
--- a/lib/l10n/en.arb
+++ b/lib/l10n/en.arb
@@ -225,7 +225,7 @@
   "tm_": "Turkmenistan",
   "tn_": "Tunisia",
   "to_": "Tonga",
-  "tr_": "Turkey",
+  "tr_": "Türkiye",
   "tt_": "Trinidad and Tobago",
   "tv_": "Tuvalu",
   "tw_": "Taiwan",


### PR DESCRIPTION
Turkey's new name in UN is now Türkiye. You can check the following article:

https://turkiye.un.org/en/184798-turkeys-name-changed-t%C3%BCrkiye#:~:text=The%20country%20name%20%22T%C3%BCrkiye%22%20is,to%20T%C3%BCrkiye%20at%20the%20UN.