### PR TITLE
fix: copy/paste not possible

### DIFF
--- a/lib/src/widgets/phone_field_state.dart
+++ b/lib/src/widgets/phone_field_state.dart
@@ -40,6 +40,15 @@ class PhoneFieldState extends State<PhoneField> {
     SystemChannels.textInput.invokeMethod('TextInput.show');
   }
 
+  // TODO: Would be cleaner if we could infer it from
+  // TextField._defaultContextMenuBuilder, but it's private
+  static Widget _defaultContextMenuBuilder(
+      BuildContext context, EditableTextState editableTextState) {
+    return AdaptiveTextSelectionToolbar.editableText(
+      editableTextState: editableTextState,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     // the idea here is to have a mouse region that surround the input which
@@ -83,7 +92,8 @@ class PhoneFieldState extends State<PhoneField> {
             smartDashesType: widget.smartDashesType,
             smartQuotesType: widget.smartQuotesType,
             enableSuggestions: widget.enableSuggestions,
-            contextMenuBuilder: widget.contextMenuBuilder,
+            contextMenuBuilder:
+                widget.contextMenuBuilder ?? _defaultContextMenuBuilder,
             showCursor: widget.showCursor,
             onEditingComplete: widget.onEditingComplete,
             onSubmitted: widget.onSubmitted,


### PR DESCRIPTION
- fix: copy/paste wasn't possible due to context menu builder being passed as null

As a workaround, until this is merged and released, you can simply add the following prop to your `PhoneFormField` widget:

```diff
PhoneFormField(
   validator: PhoneValidator.required(),
+  contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
+    return AdaptiveTextSelectionToolbar.editableText(
+      editableTextState: editableTextState,
+    );
+  },