### PR TITLE
Option to exclude country selector chip from focus

### DIFF
--- a/lib/src/phone_form_field.dart
+++ b/lib/src/phone_form_field.dart
@@ -75,6 +75,9 @@ class PhoneFormField extends FormField<PhoneNumber> {
   /// whether the flag is shown inside the country button
   final bool showFlagInInput;
 
+  /// whether [countrySelectorNavigator] should be excluded from focus traversal
+  final bool skipFocusOnCountryNavigator;
+
   // textfield inputs
   final InputDecoration decoration;
   final TextInputType keyboardType;
@@ -122,6 +125,7 @@ class PhoneFormField extends FormField<PhoneNumber> {
     this.shouldFormat = true,
     this.onChanged,
     this.focusNode,
+    this.skipFocusOnCountryNavigator = false,
     this.showFlagInInput = true,
     this.countrySelectorNavigator = const CountrySelectorNavigator.page(),
     @Deprecated(

--- a/lib/src/phone_form_field.dart
+++ b/lib/src/phone_form_field.dart
@@ -75,9 +75,6 @@ class PhoneFormField extends FormField<PhoneNumber> {
   /// whether the flag is shown inside the country button
   final bool showFlagInInput;
 
-  /// whether [countrySelectorNavigator] should be excluded from focus traversal
-  final bool skipFocusOnCountryNavigator;
-
   // textfield inputs
   final InputDecoration decoration;
   final TextInputType keyboardType;
@@ -125,7 +122,6 @@ class PhoneFormField extends FormField<PhoneNumber> {
     this.shouldFormat = true,
     this.onChanged,
     this.focusNode,
-    this.skipFocusOnCountryNavigator = false,
     this.showFlagInInput = true,
     this.countrySelectorNavigator = const CountrySelectorNavigator.page(),
     @Deprecated(

--- a/lib/src/phone_form_field_state.dart
+++ b/lib/src/phone_form_field_state.dart
@@ -137,24 +137,27 @@ class PhoneFormFieldState extends FormFieldState<PhoneNumber> {
   }
 
   Widget _buildCountryCodeChip(BuildContext context) {
-    return AnimatedBuilder(
-      animation: controller,
-      builder: (context, _) => CountryButton(
-        key: const ValueKey('country-code-chip'),
-        isoCode: controller.value.isoCode,
-        onTap: widget.enabled ? _selectCountry : null,
-        padding: _computeCountryButtonPadding(context),
-        showFlag: widget.showFlagInInput,
-        showIsoCode: widget.showIsoCodeInInput,
-        showDialCode: widget.showDialCode,
-        textStyle: widget.countryCodeStyle ??
-            widget.decoration.labelStyle ??
-            TextStyle(
-              fontSize: 16,
-              color: Theme.of(context).textTheme.bodySmall?.color,
-            ),
-        flagSize: widget.flagSize,
-        enabled: widget.enabled,
+    return ExcludeFocus(
+      excluding: widget.skipFocusOnCountryNavigator,
+      child: AnimatedBuilder(
+        animation: controller,
+        builder: (context, _) => CountryButton(
+          key: const ValueKey('country-code-chip'),
+          isoCode: controller.value.isoCode,
+          onTap: widget.enabled ? _selectCountry : null,
+          padding: _computeCountryButtonPadding(context),
+          showFlag: widget.showFlagInInput,
+          showIsoCode: widget.showIsoCodeInInput,
+          showDialCode: widget.showDialCode,
+          textStyle: widget.countryCodeStyle ??
+              widget.decoration.labelStyle ??
+              TextStyle(
+                fontSize: 16,
+                color: Theme.of(context).textTheme.bodySmall?.color,
+              ),
+          flagSize: widget.flagSize,
+          enabled: widget.enabled,
+        ),
       ),
     );
   }

--- a/lib/src/phone_form_field_state.dart
+++ b/lib/src/phone_form_field_state.dart
@@ -138,7 +138,6 @@ class PhoneFormFieldState extends FormFieldState<PhoneNumber> {
 
   Widget _buildCountryCodeChip(BuildContext context) {
     return ExcludeFocus(
-      excluding: widget.skipFocusOnCountryNavigator,
       child: AnimatedBuilder(
         animation: controller,
         builder: (context, _) => CountryButton(


### PR DESCRIPTION
Gives a better UX on mobile forms whose fields have `textInputAction: TextInputAction.next` if the country selector chip is excluded from focus. This PR add the property `skipFocusOnCountryNavigator`(which defaults to false) to the PhoneFormField to control that.