### PR TITLE
feat: add option to enable or disable asset flag preload

### DIFF
--- a/lib/src/phone_form_field.dart
+++ b/lib/src/phone_form_field.dart
@@ -61,6 +61,11 @@ class PhoneFormField extends FormField<PhoneNumber> {
   /// The style of the country selector button
   final CountryButtonStyle countryButtonStyle;
 
+  /// Whether the flag assets should be preloaded. It improves performance
+  /// by downloading them upfront (default). If set to false the assets will be
+  /// lazy loaded.
+  final bool isFlagPreloadEnabled;
+
   // textfield inputs
   final InputDecoration decoration;
   final TextInputType keyboardType;
@@ -168,6 +173,7 @@ class PhoneFormField extends FormField<PhoneNumber> {
     this.scrollController,
     this.autofillHints,
     this.enableIMEPersonalizedLearning = true,
+    this.isFlagPreloadEnabled = true,
   })  : assert(
           initialValue == null || controller == null,
           'One of initialValue or controller can be specified at a time',

--- a/lib/src/phone_form_field_state.dart
+++ b/lib/src/phone_form_field_state.dart
@@ -20,7 +20,7 @@ class PhoneFormFieldState extends FormFieldState<PhoneNumber> {
         );
     controller.addListener(_onControllerValueChanged);
     focusNode = widget.focusNode ?? FocusNode();
-    CountrySelector.preloadFlags();
+    if (widget.isFlagPreloadEnabled) CountrySelector.preloadFlags();
   }
 
   @override


### PR DESCRIPTION
This change offers the option of lazy loading for scenarios where upfront asset download isn't necessary or detrimental to the performance of the page.