### PR TITLE
fix: handle change on country selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [9.2.5]
+- fix: handle change on country selection. onChanged callback would trigger if country field is updated 
+
 ## [9.2.4]
 - upgrade metadata
 - Do not preload flags by default anymore. Use [PhoneFormField.preloadFlags()] to preload flags

--- a/lib/src/phone_form_field_state.dart
+++ b/lib/src/phone_form_field_state.dart
@@ -70,6 +70,8 @@ class PhoneFormFieldState extends FormFieldState<PhoneNumber> {
     final selected = await widget.countrySelectorNavigator.show(context);
     if (selected != null) {
       controller.changeCountry(selected);
+      didChange(controller.value);
+      widget.onChanged?.call(controller.value);
     }
     focusNode.requestFocus();
   }

--- a/test/phone_form_field_test.dart
+++ b/test/phone_form_field_test.dart
@@ -250,6 +250,32 @@ void main() {
       );
     });
 
+    testWidgets('Should call onChange when countryCode updated', (tester) async {
+      bool changed = false;
+      PhoneNumber? phoneNumber =
+      PhoneNumber.parse('', destinationCountry: IsoCode.FR);
+      void onChanged(PhoneNumber? p) {
+        changed = true;
+        phoneNumber = p;
+      }
+
+      await tester.pumpWidget(
+        getWidget(
+          initialValue: phoneNumber,
+          onChanged: onChanged,
+        ),
+      );
+      await tester.tap(find.byType(CountryButton));
+      await tester.pumpAndSettle();
+      expect(find.byType(CountrySelectorPage), findsOneWidget);
+      await tester.tap(find.byType(ListTile).first);
+      expect(true, changed);
+      expect(
+        phoneNumber,
+        equals(PhoneNumber.parse('', destinationCountry: IsoCode.AF)),
+      );
+    });
+
     group('validator', () {
       testWidgets(
           'Should display invalid message when PhoneValidator.valid is used '

--- a/test/phone_form_field_test.dart
+++ b/test/phone_form_field_test.dart
@@ -269,7 +269,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byType(CountrySelectorPage), findsOneWidget);
       await tester.tap(find.byType(ListTile).first);
-      expect(true, changed);
+      expect(changed, equals(true));
       expect(
         phoneNumber,
         equals(PhoneNumber.parse('', destinationCountry: IsoCode.AF)),


### PR DESCRIPTION
The onChange does not trigger when country is updated which is unexpected 
The didChange was not called because of which the form was on a bad state

fix: handle change on country selection