### PR TITLE
Add missing `countries` and `favorites` params to `CountrySelectorNavigator.page` factory

### DIFF
--- a/lib/src/country_selector_navigator.dart
+++ b/lib/src/country_selector_navigator.dart
@@ -98,6 +98,8 @@ abstract class CountrySelectorNavigator {
       CountrySelectorNavigator.page;
 
   const factory CountrySelectorNavigator.page({
+    List<IsoCode>? countries,
+    List<IsoCode>? favorites,
     bool addSeparator,
     bool showCountryCode,
     bool sortCountries,


### PR DESCRIPTION
Currently, `PageNavigator._` private constructor accepts `super.countries` and `super.favorites` params, but they are not exposed in `CountrySelectorNavigator.page` public factory method, thus library users are not able to customize dispayed countries and favorites lists. This change adds those missing params to `CountrySelectorNavigator.page` factory.