### PR TITLE
gray scale country flag when disabling the field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,7 @@
 
 ## [6.1.1] 22/07/2022
 
-- Readd RTL support
+- Read RTL support
 - Removed diacritics from search
 - Added height and width to dialog
 
@@ -225,7 +225,7 @@
 - Remove deprecated constructor, use factories instead
 - Fix a cursor bug where the cursor would be misplaced
 - Added `PageNavigator` for country selection.
-- Refactor of internal to accomodate for different UI for country selection
+- Refactor of internal to accommodate for different UI for country selection
 - Slight refactor of search process
 - Added possibility of styling hint text (thanks @xvrh)
 - [Breaking] use updated version of phone_number_parser which uses `IsoCode` for iso codes instead
@@ -300,7 +300,7 @@
 
 # Validation
 
-- Add PhoneValidator class to easily customize validation and defaults localization error messagees
+- Add PhoneValidator class to easily customize validation and defaults localization error messages
 - Add PhoneFormField `validator` property
 - **[BREAKING CHANGE]** Remove `PhoneFormField` properties `errorText` & `phoneNumberType`. Define `validator` property instead with `PhoneValidator.invalid*`
 
@@ -400,7 +400,7 @@ Thus it was decided that it was not worth it to keep backward compatibility and 
 
 ## [0.0.3] - 13 / 04 / 2021
 
-- Breaking: inputBorder parameter replaced by inputDecoration for more maneability
+- Breaking: inputBorder parameter replaced by inputDecoration for more manageability
 
 ## [0.0.2] - 12 / 04 / 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [10.0.5]
+
+- adds `grayScaleFlagOnDisabled` for `CountryButtonStyle` to give more natural handling of disabled state
+
 ## [10.0.4]
 
 - added backgroundColor property to BottomSheet, DraggableModalSheet, ModalSheet, Dialog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [10.0.5]
 
-- adds `grayScaleFlagOnDisabled` for `CountryButtonStyle` to give more natural handling of disabled state
+- handle disabled state for `CircleFlag` in `CountryButtonStyle` using gray scale color filter to give more natural handling of disabled state
 
 ## [10.0.4]
 

--- a/lib/src/country_button.dart
+++ b/lib/src/country_button.dart
@@ -11,6 +11,7 @@ class CountryButton extends StatelessWidget {
   final TextStyle? textStyle;
   final EdgeInsets padding;
   final double flagSize;
+  final bool grayScaleFlagOnDisabled;
   final bool showFlag;
   final bool showDialCode;
   final bool showIsoCode;
@@ -24,6 +25,7 @@ class CountryButton extends StatelessWidget {
     this.textStyle,
     this.padding = const EdgeInsets.fromLTRB(12, 16, 4, 16),
     this.flagSize = 20,
+    this.grayScaleFlagOnDisabled = false,
     this.showFlag = true,
     this.showDialCode = true,
     this.showIsoCode = false,
@@ -58,9 +60,12 @@ class CountryButton extends StatelessWidget {
             ],
             if (showFlag) ...[
               ExcludeSemantics(
-                child: CircleFlag(
-                  isoCode.name,
-                  size: flagSize,
+                child: GrayScale(
+                  visible: !enabled && grayScaleFlagOnDisabled,
+                  child: CircleFlag(
+                    isoCode.name,
+                    size: flagSize,
+                  ),
                 ),
               ),
               const SizedBox(width: 8),
@@ -78,6 +83,34 @@ class CountryButton extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class GrayScale extends StatelessWidget {
+  final bool visible;
+  final Widget child;
+
+  const GrayScale({
+    super.key,
+    required this.child,
+    this.visible = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!visible) {
+      return child;
+    }
+
+    return ColorFiltered(
+      colorFilter: const ColorFilter.matrix(<double>[
+        0.2126, 0.7152, 0.0722, 0, 0, //
+        0.2126, 0.7152, 0.0722, 0, 0,
+        0.2126, 0.7152, 0.0722, 0, 0,
+        0, 0, 0, 1, 0,
+      ]),
+      child: child,
     );
   }
 }

--- a/lib/src/country_button.dart
+++ b/lib/src/country_button.dart
@@ -11,7 +11,6 @@ class CountryButton extends StatelessWidget {
   final TextStyle? textStyle;
   final EdgeInsets padding;
   final double flagSize;
-  final bool grayScaleFlagOnDisabled;
   final bool showFlag;
   final bool showDialCode;
   final bool showIsoCode;
@@ -25,7 +24,6 @@ class CountryButton extends StatelessWidget {
     this.textStyle,
     this.padding = const EdgeInsets.fromLTRB(12, 16, 4, 16),
     this.flagSize = 20,
-    this.grayScaleFlagOnDisabled = false,
     this.showFlag = true,
     this.showDialCode = true,
     this.showIsoCode = false,
@@ -61,7 +59,7 @@ class CountryButton extends StatelessWidget {
             if (showFlag) ...[
               ExcludeSemantics(
                 child: GrayScale(
-                  visible: !enabled && grayScaleFlagOnDisabled,
+                  visible: !enabled,
                   child: CircleFlag(
                     isoCode.name,
                     size: flagSize,

--- a/lib/src/country_button_style.dart
+++ b/lib/src/country_button_style.dart
@@ -12,8 +12,11 @@ class CountryButtonStyle {
   /// The radius of the flag in the country button
   final double flagSize;
 
-  /// Wether to show the country flag in the country button
+  /// Whether to show the country flag in the country button
   final bool showFlag;
+
+  /// Whether to apply greyscale filter on flag icon if control is disabled
+  final bool grayScaleFlagOnDisabled;
 
   /// Whether to show Dial Code in the country button
   /// setting this to false will hide, for example, (+1)
@@ -30,6 +33,7 @@ class CountryButtonStyle {
     this.padding,
     this.flagSize = 20,
     this.showFlag = true,
+    this.grayScaleFlagOnDisabled = true,
     this.showDialCode = true,
     this.showIsoCode = false,
     this.showDropdownIcon = true,
@@ -39,6 +43,7 @@ class CountryButtonStyle {
     TextStyle? textStyle,
     EdgeInsets? padding,
     double? flagSize,
+    bool? grayScaleFlagOnDisabled,
     bool? showFlag,
     bool? showDialCode,
     bool? showIsoCode,
@@ -48,6 +53,8 @@ class CountryButtonStyle {
       textStyle: textStyle ?? this.textStyle,
       padding: padding ?? this.padding,
       flagSize: flagSize ?? this.flagSize,
+      grayScaleFlagOnDisabled:
+          grayScaleFlagOnDisabled ?? this.grayScaleFlagOnDisabled,
       showFlag: showFlag ?? this.showFlag,
       showDialCode: showDialCode ?? this.showDialCode,
       showIsoCode: showIsoCode ?? this.showIsoCode,

--- a/lib/src/country_button_style.dart
+++ b/lib/src/country_button_style.dart
@@ -15,9 +15,6 @@ class CountryButtonStyle {
   /// Whether to show the country flag in the country button
   final bool showFlag;
 
-  /// Whether to apply greyscale filter on flag icon if control is disabled
-  final bool grayScaleFlagOnDisabled;
-
   /// Whether to show Dial Code in the country button
   /// setting this to false will hide, for example, (+1)
   final bool showDialCode;
@@ -33,7 +30,6 @@ class CountryButtonStyle {
     this.padding,
     this.flagSize = 20,
     this.showFlag = true,
-    this.grayScaleFlagOnDisabled = true,
     this.showDialCode = true,
     this.showIsoCode = false,
     this.showDropdownIcon = true,
@@ -43,7 +39,6 @@ class CountryButtonStyle {
     TextStyle? textStyle,
     EdgeInsets? padding,
     double? flagSize,
-    bool? grayScaleFlagOnDisabled,
     bool? showFlag,
     bool? showDialCode,
     bool? showIsoCode,
@@ -53,8 +48,6 @@ class CountryButtonStyle {
       textStyle: textStyle ?? this.textStyle,
       padding: padding ?? this.padding,
       flagSize: flagSize ?? this.flagSize,
-      grayScaleFlagOnDisabled:
-          grayScaleFlagOnDisabled ?? this.grayScaleFlagOnDisabled,
       showFlag: showFlag ?? this.showFlag,
       showDialCode: showDialCode ?? this.showDialCode,
       showIsoCode: showIsoCode ?? this.showIsoCode,

--- a/lib/src/phone_form_field_state.dart
+++ b/lib/src/phone_form_field_state.dart
@@ -177,8 +177,6 @@ class PhoneFormFieldState extends FormFieldState<PhoneNumber> {
             padding: _computeCountryButtonPadding(context),
             showFlag: widget.countryButtonStyle.showFlag,
             showIsoCode: widget.countryButtonStyle.showIsoCode,
-            grayScaleFlagOnDisabled:
-                widget.countryButtonStyle.grayScaleFlagOnDisabled,
             showDialCode: widget.countryButtonStyle.showDialCode,
             showDropdownIcon: widget.countryButtonStyle.showDropdownIcon,
             textStyle: widget.countryButtonStyle.textStyle,

--- a/lib/src/phone_form_field_state.dart
+++ b/lib/src/phone_form_field_state.dart
@@ -177,6 +177,8 @@ class PhoneFormFieldState extends FormFieldState<PhoneNumber> {
             padding: _computeCountryButtonPadding(context),
             showFlag: widget.countryButtonStyle.showFlag,
             showIsoCode: widget.countryButtonStyle.showIsoCode,
+            grayScaleFlagOnDisabled:
+                widget.countryButtonStyle.grayScaleFlagOnDisabled,
             showDialCode: widget.countryButtonStyle.showDialCode,
             showDropdownIcon: widget.countryButtonStyle.showDropdownIcon,
             textStyle: widget.countryButtonStyle.textStyle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: phone_form_field
 description: Flutter phone input integrated with flutter internationalization
-version: 10.0.4
+version: 10.0.5
 homepage: https://github.com/cedvdb/phone_form_field
 
 environment:

--- a/test/phone_form_field_test.dart
+++ b/test/phone_form_field_test.dart
@@ -65,7 +65,23 @@ void main() {
 
     testWidgets('Should display flag', (tester) async {
       await tester.pumpWidget(getWidget());
-      expect(find.byType(CircleFlag), findsWidgets);
+      final countryButtonFinder = find.byType(CountryButton);
+
+      expect(
+        find.descendant(
+          of: countryButtonFinder,
+          matching: find.byType(CircleFlag),
+        ),
+        findsOneWidget,
+      );
+
+      expect(
+        find.descendant(
+          of: countryButtonFinder,
+          matching: find.byType(ColorFiltered),
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets(
@@ -94,6 +110,21 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.byType(CountrySelectorPage), findsOneWidget);
       });
+
+      testWidgets('Should grey scale flag when disabled', (tester) async {
+        await tester.pumpWidget(getWidget(enabled: false));
+        final colorFil = find.byType(ColorFiltered);
+        expect(colorFil, findsOne);
+
+        expect(
+          find.descendant(
+            of: colorFil,
+            matching: find.byType(CircleFlag),
+          ),
+          findsOneWidget,
+        );
+      });
+
       testWidgets('Should hide flag', (tester) async {
         await tester.pumpWidget(getWidget(showFlagInInput: false));
         expect(find.byType(CircleFlag), findsNothing);


### PR DESCRIPTION
Hi @cedvdb 

There were no handling for disabled state in case of country flag field so added an ability to apply grayscale filter in a non breaking way


<img width="386" alt="image" src="https://github.com/user-attachments/assets/e5920f75-7f30-4a9d-9ea5-b55eed25fe60" />


## Checklist

- [x] I have bumped the version in pubspec.yaml
- [x] I have added an entry in changelog.md for the new pubspec version
- [ ] (if applicable) I have added "Closes #1234" to this termplate to automatically close related issues.
- [ ] (not required if no sensible change has been made eg: Localization) I have added tests that prove my fix is effective or that my feature works. 


