### PR TITLE
Limit length on PhoneFormField

### DIFF
--- a/lib/src/phone_form_field.dart
+++ b/lib/src/phone_form_field.dart
@@ -6,6 +6,7 @@ import 'package:flutter_country_selector/flutter_country_selector.dart';
 import 'package:phone_form_field/phone_form_field.dart';
 import 'package:phone_form_field/src/phone_field_semantics.dart';
 import 'package:phone_form_field/src/validation/allowed_characters.dart';
+import 'package:phone_numbers_parser/metadata.dart';
 import 'package:phone_numbers_parser/phone_numbers_parser.dart';
 
 part 'phone_controller.dart';
@@ -94,6 +95,7 @@ class PhoneFormField extends FormField<PhoneNumber> {
   final Iterable<String>? autofillHints;
   final bool enableIMEPersonalizedLearning;
   final List<TextInputFormatter>? inputFormatters;
+  final bool limitLength;
 
   static preloadFlags() => CountrySelector.preloadFlags();
 
@@ -151,6 +153,7 @@ class PhoneFormField extends FormField<PhoneNumber> {
     this.scrollController,
     this.autofillHints,
     this.enableIMEPersonalizedLearning = true,
+    this.limitLength = false,
   })  : assert(
           initialValue == null || controller == null,
           'One of initialValue or controller can be specified at a time',

--- a/test/phone_form_field_test.dart
+++ b/test/phone_form_field_test.dart
@@ -22,6 +22,7 @@ void main() {
       bool showDropdownIcon = true,
       PhoneNumberInputValidator Function(BuildContext)? validatorBuilder,
       bool enabled = true,
+      bool limitLength = false,
     }) =>
         MaterialApp(
           localizationsDelegates: PhoneFieldLocalization.delegates,
@@ -45,6 +46,7 @@ void main() {
                   validator: validatorBuilder?.call(context),
                   enabled: enabled,
                   autovalidateMode: AutovalidateMode.onUserInteraction,
+                  limitLength: limitLength,
                 ),
               );
             }),
@@ -696,6 +698,22 @@ void main() {
         formKey.currentState?.reset();
         await tester.pumpAndSettle();
         expect(find.text(national), findsNothing);
+      });
+
+      testWidgets(
+          'Should cut off the TextField value when limitLength is true and a long nsn for the selected country is provided',
+          (tester) async {
+        PhoneNumber? phoneNumber = PhoneNumber.parse('+32');
+
+        await tester.pumpWidget(
+            getWidget(initialValue: phoneNumber, limitLength: true));
+        await tester.pump(const Duration(seconds: 1));
+        const national = '477 88 99 22';
+        const extraNonAllowedNumber = '2';
+        final phoneField = find.byType(PhoneFormField);
+        await tester.enterText(phoneField, national + extraNonAllowedNumber);
+        await tester.pumpAndSettle();
+        expect(find.text(national), findsOneWidget);
       });
     });
 


### PR DESCRIPTION
This PR adds a new property `limitLength` to `PhoneFormField` so user is not able to input more digits when the selected country doesn't requires more. It is by default in `false`.


## Checklist

Closes [#261](https://github.com/cedvdb/phone_form_field/issues/261)

- [x] I have bumped the version in pubspec.yaml
- [x] I have added an entry in changelog.md for the new pubspec version
- [x] (if applicable) I have added "Closes #1234" to this termplate to automatically close related issues.
- [x] (not required if no sensible change has been made eg: Localization) I have added tests that prove my fix is effective or that my feature works. 


