### PR TITLE
Fix text selection on LimitMaxLengthFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `borderRadius` to `CountryButtonStyle` to allow configuring the borderRadius of the country button InkWell.
 - Adjusted padding to be more in line with latest changes for text fields
+- Fix text selection on `LimitMaxLengthFormatter`
 
 ## [10.0.7]
 

--- a/lib/src/validation/limit_max_length_formatter.dart
+++ b/lib/src/validation/limit_max_length_formatter.dart
@@ -12,7 +12,10 @@ class LimitMaxLengthFormatter extends TextInputFormatter {
 
     if (rawInput.length > maxLength) {
       rawInput = rawInput.substring(0, maxLength);
-      return newValue.copyWith(text: rawInput);
+      return newValue.copyWith(
+        text: rawInput,
+        selection: TextSelection.collapsed(offset: rawInput.length),
+      );
     }
 
     return newValue;


### PR DESCRIPTION
This PR fixes an issue where, if the cursor is placed at the end of the text and the input is then trimmed (due to limit max formatter), the cursor ends up in an invalid position — beyond the new text length.
 
## Checklist

- [x] I have bumped the version in pubspec.yaml
- [x] I have added an entry in changelog.md for the new pubspec version
- [x] (if applicable) I have added "Closes #1234" to this termplate to automatically close related issues.
- [x] (not required if no sensible change has been made eg: Localization) I have added tests that prove my fix is effective or that my feature works. 


