### PR TITLE
fix(phone_form_field): Dispose focus node in PhoneFormFieldState

### DIFF
--- a/lib/src/phone_form_field_state.dart
+++ b/lib/src/phone_form_field_state.dart
@@ -29,6 +29,7 @@ class PhoneFormFieldState extends FormFieldState<PhoneNumber> {
   @override
   void dispose() {
     controller.removeListener(_onControllerValueChanged);
+    focusNode.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
Ensure the focus node is properly disposed of in the dispose method to prevent memory leaks and improve resource management.

Closes #295 

## Checklist

- [ ] I have bumped the version in pubspec.yaml
- [ ] I have added an entry in changelog.md for the new pubspec version
- [x] (if applicable) I have added "Closes #1234" to this termplate to automatically close related issues.
- [ ] (not required if no sensible change has been made eg: Localization) I have added tests that prove my fix is effective or that my feature works. 


